### PR TITLE
Swap arguments for currency conversion

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -13,7 +13,7 @@ const CONVERSION_RATES = {
   }
 }
 
-const convert = ({ value, currency }) => (toCurrency) => {
+const convert = (toCurrency) => ({ value, currency }) => {
   if (!value || !currency) throw new Error('value and currency is required for conversion')
   const rate = CONVERSION_RATES[currency]?.[toCurrency]
   if (!rate) throw new Error('Non-supported currency')

--- a/src/utils/index.test.js
+++ b/src/utils/index.test.js
@@ -3,20 +3,20 @@ const { convert } = require('.')
 
 describe('correct conversion between currencies', () => {
   test('Unsupported currencies are handled', () => {
-    expect(() => convert({ value: 10, currency: 'SEK' })('NOK')).toThrowError('Non-supported currency')
-    expect(() => convert({ value: 10, currency: 'NOK' })('SEK')).toThrowError('Non-supported currency')
+    expect(() => convert('NOK')({ value: 10, currency: 'SEK' })).toThrowError('Non-supported currency')
+    expect(() => convert('SEK')({ value: 10, currency: 'NOK' })).toThrowError('Non-supported currency')
   })
 
   test('Converts SEK <-> EUR correct', () => {
-    expect(convert({ value: 25, currency: 'SEK'})('EUR')).toEqual({ value: 2.5, currency: 'EUR' })
-    expect(convert({ value: 2.5, currency: 'EUR'})('SEK')).toEqual({ value: 25, currency: 'SEK' })
+    expect(convert('EUR')({ value: 25, currency: 'SEK'})).toEqual({ value: 2.5, currency: 'EUR' })
+    expect(convert('SEK')({ value: 2.5, currency: 'EUR'})).toEqual({ value: 25, currency: 'SEK' })
   })
   test('Converts SEK <-> DKK correct', () => {
-    expect(convert({ value: 25, currency: 'SEK'})('DKK')).toEqual({ value: 17.5, currency: 'DKK' })
-    expect(convert({ value: 17.5, currency: 'DKK'})('SEK')).toEqual({ value: 25, currency: 'SEK' })
+    expect(convert('DKK')({ value: 25, currency: 'SEK'})).toEqual({ value: 17.5, currency: 'DKK' })
+    expect(convert('SEK')({ value: 17.5, currency: 'DKK'})).toEqual({ value: 25, currency: 'SEK' })
   })
   test('Converts EUR <-> DKK correct', () => {
-    expect(convert({ value: 25, currency: 'EUR'})('DKK')).toEqual({ value: 192.31, currency: 'DKK' })
-    expect(convert({ value: 192.31, currency: 'DKK'})('EUR')).toEqual({ value: 25, currency: 'EUR' })
+    expect(convert('DKK')({ value: 25, currency: 'EUR'})).toEqual({ value: 192.31, currency: 'DKK' })
+    expect(convert('EUR')({ value: 192.31, currency: 'DKK'})).toEqual({ value: 25, currency: 'EUR' })
   })
 })


### PR DESCRIPTION
It makes more sense to have a `convertToSek` function than `convert100Sek` (to the currency of your choice) 🙃